### PR TITLE
fix: resolve date discrepancy and timezone issues (fixes issue #43)

### DIFF
--- a/app/src/app/admin/challenges/page.tsx
+++ b/app/src/app/admin/challenges/page.tsx
@@ -81,8 +81,8 @@ export default async function AdminChallengesPage() {
                                 </td>
                                 <td className="px-4 py-4 sm:px-6 text-neutral-500 font-mono text-[10px] tracking-tighter">
                                     <div className="flex flex-col">
-                                        <span className="flex items-center gap-1"><span className="text-neutral-700 font-black">START:</span> <DateDisplay date={challenge.startDate} /></span>
-                                        <span className="flex items-center gap-1"><span className="text-neutral-700 font-black">END:</span> <DateDisplay date={challenge.endDate} /></span>
+                                        <span className="flex items-center gap-1"><span className="text-neutral-700 font-black">START:</span> <DateDisplay date={challenge.startDate} timeZone={challenge.timezone} /></span>
+                                        <span className="flex items-center gap-1"><span className="text-neutral-700 font-black">END:</span> <DateDisplay date={challenge.endDate} timeZone={challenge.timezone} /></span>
                                     </div>
                                 </td>
                                 <td className="px-4 py-4 sm:px-6 text-right font-black text-neutral-400">

--- a/app/src/app/challenges/page.tsx
+++ b/app/src/app/challenges/page.tsx
@@ -74,7 +74,7 @@ export default async function ChallengesExplorePage() {
                                 <div className="space-y-3 mb-8 flex-1">
                                     <div className="flex items-center gap-2 text-xs text-neutral-500 font-bold tracking-wider">
                                         <Calendar className="h-4 w-4" />
-                                        <DateDisplay date={challenge.startDate} /> — <DateDisplay date={challenge.endDate} />
+                                        <DateDisplay date={challenge.startDate} timeZone={challenge.timezone} /> — <DateDisplay date={challenge.endDate} timeZone={challenge.timezone} />
                                     </div>
                                     <div className="flex items-center gap-2 text-xs text-neutral-500 font-bold tracking-wider">
                                         <Users className="h-4 w-4" />

--- a/app/src/app/components/DateDisplay.tsx
+++ b/app/src/app/components/DateDisplay.tsx
@@ -1,13 +1,33 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { toZonedTime } from 'date-fns-tz'
+import { format } from 'date-fns'
+import { isMidnightUTC } from '@/lib/dateUtils'
 
-export default function DateDisplay({ date, className }: { date: Date | string, className?: string }) {
+export default function DateDisplay({ date, className, timeZone = 'UTC' }: { date: Date | string, className?: string, timeZone?: string }) {
     const [formattedDate, setFormattedDate] = useState<string>('')
 
     useEffect(() => {
-        setFormattedDate(new Date(date).toLocaleDateString())
-    }, [date])
+        if (!date) return;
+
+        try {
+            // Heuristic: If the date is exactly midnight UTC, it's likely a "Date Only" field (startDate/endDate).
+            // In this case, we display the UTC date components to match the "Calendar Date" stored in DB.
+            const isMidnightUTC = (d: Date | string) => {
+                const dateObj = new Date(d);
+                return dateObj.getUTCHours() === 0 && dateObj.getUTCMinutes() === 0 && dateObj.getUTCSeconds() === 0 && dateObj.getUTCMilliseconds() === 0;
+            };
+
+            const targetTimeZone = isMidnightUTC(date) ? 'UTC' : timeZone;
+
+            const zonedDate = toZonedTime(date, targetTimeZone);
+            setFormattedDate(format(zonedDate, 'M/d/yyyy'));
+        } catch (e) {
+            console.error("Date formatting error", e);
+            setFormattedDate(String(date));
+        }
+    }, [date, timeZone])
 
     if (!formattedDate) {
         // Render a skeleton or empty span to avoid layout shift

--- a/app/src/lib/dateUtils.ts
+++ b/app/src/lib/dateUtils.ts
@@ -26,3 +26,8 @@ export function parseDateInTimezone(dateString: string, timeZone: string = 'Amer
     // appending T00:00:00 to ensure we target start of day
     return fromZonedTime(`${dateString}T00:00:00`, timeZone);
 }
+
+export function isMidnightUTC(date: Date | string): boolean {
+    const d = new Date(date);
+    return d.getUTCHours() === 0 && d.getUTCMinutes() === 0 && d.getUTCSeconds() === 0 && d.getUTCMilliseconds() === 0;
+}


### PR DESCRIPTION
The timestamp saved in the database for startDate and endDate was read by the backend as a UTC timestamp, ignoring the additional timezone field. 